### PR TITLE
Ledepede1 patch 1

### DIFF
--- a/src/s_main.lua
+++ b/src/s_main.lua
@@ -5,12 +5,18 @@ Standalone = {
 local ESX, vRP, QBCore = nil
 local FrameworkSetup = false
 
+local errorMsg = "You need to setup the framework!"
+
 local function checkState()
     if FrameworkSetup == false then
         return false
     else
         return true
     end
+end
+
+local function FrameworkStateErr()
+    print(errorMsg)
 end
 
 CreateThread(function()
@@ -34,7 +40,7 @@ function getUserId(source)
 end
 
 Standalone.Functions.getUser = function(src)
-    if checkState() == false then return print("You need to setup framework first") end
+    if checkState() == false then return FrameworkStateErr() end
 
     local promise = promise.new()
     local data = {}
@@ -80,7 +86,7 @@ Standalone.Functions.getUser = function(src)
 end
 
 Standalone.Functions.checkJob = function(src, job)
-    if checkState() == false then return print("You need to setup framework first") end
+    if checkState() == false then return FrameworkStateErr() end
 
     local promise = promise.new()
     local hasJob = false
@@ -116,7 +122,7 @@ Standalone.Functions.checkJob = function(src, job)
 end
 
 Standalone.Functions.notify = function(src, text, type)
-    if checkState() == false then return print("You need to setup framework first") end
+    if checkState() == false then return FrameworkStateErr() end
 
     if vRP ~= nil then
 

--- a/src/s_main.lua
+++ b/src/s_main.lua
@@ -125,7 +125,7 @@ Standalone.Functions.notify = function(src, text, type)
     if checkState() == false then return FrameworkStateErr() end
 
     if vRP ~= nil then
-
+        vRP.notify(text)
     elseif ESX ~= nil then
         local Player = ESX.GetPlayerFromId(src)
         xPlayer.showNotification(text)

--- a/src/s_main.lua
+++ b/src/s_main.lua
@@ -125,7 +125,8 @@ Standalone.Functions.notify = function(src, text, type)
     if checkState() == false then return FrameworkStateErr() end
 
     if vRP ~= nil then
-        vRP.notify(text)
+        local user_id = getUserId(src)
+        vRP.notify(user_id, text)
     elseif ESX ~= nil then
         local Player = ESX.GetPlayerFromId(src)
         xPlayer.showNotification(text)
@@ -133,9 +134,6 @@ Standalone.Functions.notify = function(src, text, type)
         TriggerClientEvent('QBCore:Notify', src, text)
     end
 end
-
-
-
 
 ---------------------------------------------------------
 -------------------- Callbacks --------------------------


### PR DESCRIPTION
Added:
`vRP.notify`,
Added a function for printing the framework mission message instead of typing print() every time.
`FrameworkStateErr()`